### PR TITLE
Permission check

### DIFF
--- a/inc/rest-api/relationships/class-rest-endpoint.php
+++ b/inc/rest-api/relationships/class-rest-endpoint.php
@@ -57,7 +57,7 @@ class REST_Endpoint {
 					'methods'             => 'GET',
 					'callback'            => [ $this, 'get_items' ],
 					'permission_callback' => function() {
-						return current_user_can( 'edit_posts' );
+						return current_user_can( 'read_wp_block' );
 					},
 					'args'                => [
 						'context' => [

--- a/inc/rest-api/relationships/class-rest-endpoint.php
+++ b/inc/rest-api/relationships/class-rest-endpoint.php
@@ -56,7 +56,9 @@ class REST_Endpoint {
 				[
 					'methods'             => 'GET',
 					'callback'            => [ $this, 'get_items' ],
-					'permission_callback' => '__return_true',
+					'permission_callback' => function() {
+						return current_user_can( 'edit_posts' );
+					},
 					'args'                => [
 						'context' => [
 							'default'  => 'view',

--- a/inc/rest-api/search/class-rest-endpoint.php
+++ b/inc/rest-api/search/class-rest-endpoint.php
@@ -54,7 +54,7 @@ class REST_Endpoint {
 				'callback'            => [ $this, 'get_items' ],
 				'schema'              => ( new WP_REST_Blocks_Controller( 'wp_block' ) )->get_item_schema(),
 				'permission_callback' => function() {
-					return current_user_can( 'edit_posts' );
+					return current_user_can( 'read_wp_block' );
 				},
 				'args'                => [
 					'context' => [

--- a/inc/rest-api/search/class-rest-endpoint.php
+++ b/inc/rest-api/search/class-rest-endpoint.php
@@ -53,7 +53,9 @@ class REST_Endpoint {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_items' ],
 				'schema'              => ( new WP_REST_Blocks_Controller( 'wp_block' ) )->get_item_schema(),
-				'permission_callback' => '__return_true',
+				'permission_callback' => function() {
+					return current_user_can( 'edit_posts' );
+				},
 				'args'                => [
 					'context' => [
 						'default'  => 'view',


### PR DESCRIPTION
I know we needed to add the permission check for the REST api route registration to not error out, but I think we should be checking that the user actually has permission to read reusable blocks and not just allow any unauthorized requests.