### PR TITLE
Ensure the reusable blocks title is title case.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -127,6 +127,8 @@ function show_wp_block_in_menu( array $args, string $post_type ) : array {
 	$args['show_in_menu'] = true;
 	$args['menu_position'] = 24;
 	$args['menu_icon'] = 'dashicons-screenoptions';
+	$args['labels']['all_items'] = _x( 'All Reusable Blocks', 'post type menu label for all_items', 'altis' );
+	$args['labels']['name'] = _x( 'Reusable Blocks', 'post type menu label for name', 'altis' );
 
 	return $args;
 }


### PR DESCRIPTION
This change ensures the menu items in the admin menu will appear in the correct case.

Steps to reproduce:
1. Open Altis admin panel
2. Observe "Reusable blocks" in sidebar

Solution
- The Title should be "Reusable Blocks"

["Reusable blocks" should be Title Case in the sidebar #475](https://github.com/humanmade/altis-cms/issues/475)

Before:
![rb-before](https://user-images.githubusercontent.com/16571365/147634787-cbc76af6-9acc-43ac-b95d-578f6b43f996.png)

After:
![rb-after](https://user-images.githubusercontent.com/16571365/147634799-95e0ea05-c488-47e7-8a8a-f2ccff0439ec.png)

