### PR TITLE
Allow use with latest asset-loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.1",
         "composer/installers": "^1.7",
-        "humanmade/asset-loader": "^0.5.0"
+        "humanmade/asset-loader": "^0.5.0 || ^0.6.1"
     },
     "require-dev": {
         "automattic/vipwpcs": "^2.0",


### PR DESCRIPTION
Expand version range for asset-loader to permit use with 0.6.0